### PR TITLE
Add Reader and Writer options

### DIFF
--- a/pkg/cache_wrapper_test.go
+++ b/pkg/cache_wrapper_test.go
@@ -52,7 +52,7 @@ func TestCacheWrapper_CacheOptions_MaxAge(t *testing.T) {
 		testCreate(t, fs, "foo", "")
 
 		ctx := context.Background()
-		f, err := fs.Open(ctx, "foo")
+		f, err := fs.Open(ctx, "foo", nil)
 		assert.NoError(t, err)
 		assert.NotZero(t, f)
 		assert.NotZero(t, f.ModTime)
@@ -60,14 +60,14 @@ func TestCacheWrapper_CacheOptions_MaxAge(t *testing.T) {
 
 		<-time.After(options.MaxAge)
 
-		_, err = fs.Open(ctx, "foo")
+		_, err = fs.Open(ctx, "foo", nil)
 		assert.Errorf(t, err, "storage foo: path exists, but is expired")
 
-		f, err = cache.Open(ctx, "foo")
+		f, err = cache.Open(ctx, "foo", nil)
 		assert.Errorf(t, err, "storage foo: path does not exist")
 
 		// Wrapper still reports expired
-		_, err = fs.Open(ctx, "foo")
+		_, err = fs.Open(ctx, "foo", nil)
 		assert.Errorf(t, err, "storage foo: path exists, but is expired")
 	})
 }

--- a/pkg/cloudstorage_fs.go
+++ b/pkg/cloudstorage_fs.go
@@ -45,7 +45,7 @@ func (c *cloudStorageFS) URL(ctx context.Context, path string, options *SignedUR
 }
 
 // Open implements FS.
-func (c *cloudStorageFS) Open(ctx context.Context, path string) (*File, error) {
+func (c *cloudStorageFS) Open(ctx context.Context, path string, options *ReaderOptions) (*File, error) {
 	b, err := c.blobBucketHandle(ctx, storage.DevstorageReadOnlyScope)
 	if err != nil {
 		return nil, err
@@ -72,12 +72,19 @@ func (c *cloudStorageFS) Open(ctx context.Context, path string) (*File, error) {
 }
 
 // Create implements FS.
-func (c *cloudStorageFS) Create(ctx context.Context, path string) (io.WriteCloser, error) {
+func (c *cloudStorageFS) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	b, err := c.blobBucketHandle(ctx, storage.DevstorageReadWriteScope)
 	if err != nil {
 		return nil, err
 	}
-	return b.NewWriter(ctx, path, nil)
+	var blobOpts *blob.WriterOptions
+	if options != nil {
+		blobOpts = &blob.WriterOptions{
+			Metadata:    options.Attributes.Metadata,
+			ContentType: options.Attributes.ContentType,
+		}
+	}
+	return b.NewWriter(ctx, path, blobOpts)
 }
 
 // Delete implements FS.

--- a/pkg/fs.go
+++ b/pkg/fs.go
@@ -34,18 +34,30 @@ type Attributes struct {
 	Size int64
 }
 
+// ReaderOptions are used to modify the behaviour of read operations.
+// Inspired from github.com/google/go-cloud/blob.ReaderOptions
+// It is provided for future extensibility.
+type ReaderOptions struct{}
+
+// WriterOptions are used to modify the behaviour of write operations.
+// Inspired from github.com/google/go-cloud/blob.WriterOptions
+// Not all options are supported by all FS
+type WriterOptions struct {
+	Attributes Attributes
+}
+
 // FS is an interface which defines a virtual filesystem.
 type FS interface {
 	Walker
 
 	// Open opens an existing file at path in the filesystem.  Callers must close the
 	// File when done to release all underlying resources.
-	Open(ctx context.Context, path string) (*File, error)
+	Open(ctx context.Context, path string, options *ReaderOptions) (*File, error)
 
 	// Create makes a new file at path in the filesystem.  Callers must close the
 	// returned WriteCloser and check the error to be sure that the file
 	// was successfully written.
-	Create(ctx context.Context, path string) (io.WriteCloser, error)
+	Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error)
 
 	// Delete removes a path from the filesystem.
 	Delete(ctx context.Context, path string) error

--- a/pkg/fs_test.go
+++ b/pkg/fs_test.go
@@ -14,7 +14,7 @@ import (
 func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 	ctx := context.Background()
 
-	f, err := fs.Open(ctx, path)
+	f, err := fs.Open(ctx, path, nil)
 	assert.NoError(t, err)
 
 	b, err := ioutil.ReadAll(f)
@@ -29,14 +29,14 @@ func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 
 func testOpenNotExists(t *testing.T, fs storage.FS, path string) {
 	ctx := context.Background()
-	_, err := fs.Open(ctx, "foo")
+	_, err := fs.Open(ctx, path, nil)
 	assert.Errorf(t, err, "storage %s: path does not exist", path)
 }
 
 func testCreate(t *testing.T, fs storage.FS, path string, content string) {
 	ctx := context.Background()
 
-	wc, err := fs.Create(ctx, path)
+	wc, err := fs.Create(ctx, path, nil)
 	assert.NoError(t, err)
 
 	_, err = io.WriteString(wc, content)

--- a/pkg/logger_wrapper.go
+++ b/pkg/logger_wrapper.go
@@ -33,9 +33,9 @@ func (l *loggerWrapper) printf(format string, v ...interface{}) {
 }
 
 // Open implements FS.  All calls to Open are logged and errors are logged separately.
-func (l *loggerWrapper) Open(ctx context.Context, path string) (*File, error) {
+func (l *loggerWrapper) Open(ctx context.Context, path string, options *ReaderOptions) (*File, error) {
 	l.printf("%v: open: %v", l.name, path)
-	f, err := l.fs.Open(ctx, path)
+	f, err := l.fs.Open(ctx, path, options)
 	if err != nil {
 		l.printf("%v: open error: %v: %v", l.name, path, err)
 	}
@@ -43,9 +43,9 @@ func (l *loggerWrapper) Open(ctx context.Context, path string) (*File, error) {
 }
 
 // Create implements FS.  All calls to Create are logged and errors are logged separately.
-func (l *loggerWrapper) Create(ctx context.Context, path string) (io.WriteCloser, error) {
+func (l *loggerWrapper) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	l.printf("%v: create: %v", l.name, path)
-	wc, err := l.fs.Create(ctx, path)
+	wc, err := l.fs.Create(ctx, path, options)
 	if err != nil {
 		l.printf("%v: create error: %v: %v", l.name, path, err)
 	}

--- a/pkg/prefix_wrapper.go
+++ b/pkg/prefix_wrapper.go
@@ -25,13 +25,13 @@ func (p *prefixWrapper) addPrefix(path string) string {
 }
 
 // Open implements FS.
-func (p *prefixWrapper) Open(ctx context.Context, path string) (*File, error) {
-	return p.fs.Open(ctx, p.addPrefix(path))
+func (p *prefixWrapper) Open(ctx context.Context, path string, options *ReaderOptions) (*File, error) {
+	return p.fs.Open(ctx, p.addPrefix(path), options)
 }
 
 // Create implements FS.
-func (p *prefixWrapper) Create(ctx context.Context, path string) (io.WriteCloser, error) {
-	return p.fs.Create(ctx, p.addPrefix(path))
+func (p *prefixWrapper) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
+	return p.fs.Create(ctx, p.addPrefix(path), options)
 }
 
 // Delete implements FS.

--- a/pkg/s3_fs.go
+++ b/pkg/s3_fs.go
@@ -23,7 +23,7 @@ type s3FS struct {
 }
 
 // Open implements FS.
-func (s *s3FS) Open(ctx context.Context, path string) (*File, error) {
+func (s *s3FS) Open(ctx context.Context, path string, options *ReaderOptions) (*File, error) {
 	b, err := s.bucketHandles(ctx)
 	if err != nil {
 		return nil, err
@@ -49,12 +49,19 @@ func (s *s3FS) Open(ctx context.Context, path string) (*File, error) {
 }
 
 // Create implements FS.
-func (s *s3FS) Create(ctx context.Context, path string) (io.WriteCloser, error) {
+func (s *s3FS) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	b, err := s.bucketHandles(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return b.NewWriter(ctx, path, nil)
+	var blobOpts *blob.WriterOptions
+	if options != nil {
+		blobOpts = &blob.WriterOptions{
+			Metadata:    options.Attributes.Metadata,
+			ContentType: options.Attributes.ContentType,
+		}
+	}
+	return b.NewWriter(ctx, path, blobOpts)
 }
 
 // Delete implements FS.

--- a/pkg/stats_wrapper.go
+++ b/pkg/stats_wrapper.go
@@ -48,8 +48,8 @@ type statsWrapper struct {
 }
 
 // Open implements FS.  All errors from Open are counted.
-func (s *statsWrapper) Open(ctx context.Context, path string) (*File, error) {
-	f, err := s.fs.Open(ctx, path)
+func (s *statsWrapper) Open(ctx context.Context, path string, options *ReaderOptions) (*File, error) {
+	f, err := s.fs.Open(ctx, path, options)
 	if err != nil {
 		s.status.Add(StatOpenErrors, 1)
 	}
@@ -58,8 +58,8 @@ func (s *statsWrapper) Open(ctx context.Context, path string) (*File, error) {
 }
 
 // Create implements FS.  All errors from Create are counted.
-func (s *statsWrapper) Create(ctx context.Context, path string) (io.WriteCloser, error) {
-	wc, err := s.fs.Create(ctx, path)
+func (s *statsWrapper) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
+	wc, err := s.fs.Create(ctx, path, options)
 	if err != nil {
 		s.status.Add(StatCreateErrors, 1)
 	}

--- a/pkg/trace_wrapper.go
+++ b/pkg/trace_wrapper.go
@@ -25,7 +25,7 @@ type traceWrapper struct {
 }
 
 // Open implements FS.  All calls to Open are logged via golang.org/x/net/trace.
-func (t *traceWrapper) Open(ctx context.Context, path string) (f *File, err error) {
+func (t *traceWrapper) Open(ctx context.Context, path string, options *ReaderOptions) (f *File, err error) {
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("%v: open: %v", t.name, path)
 		defer func() {
@@ -35,11 +35,12 @@ func (t *traceWrapper) Open(ctx context.Context, path string) (f *File, err erro
 			}
 		}()
 	}
-	return t.fs.Open(ctx, path)
+	return t.fs.Open(ctx, path, options)
 }
 
+
 // Create implements FS.  All calls to Create are logged via golang.org/x/net/trace.
-func (t *traceWrapper) Create(ctx context.Context, path string) (wc io.WriteCloser, err error) {
+func (t *traceWrapper) Create(ctx context.Context, path string, options *WriterOptions) (wc io.WriteCloser, err error) {
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("%v: create: %v", t.name, path)
 		defer func() {
@@ -49,7 +50,7 @@ func (t *traceWrapper) Create(ctx context.Context, path string) (wc io.WriteClos
 			}
 		}()
 	}
-	return t.fs.Create(ctx, path)
+	return t.fs.Create(ctx, path, options)
 }
 
 // Delete implements FS.  All calls to Delete are logged via golang.org/x/net/trace.


### PR DESCRIPTION
Allows greater flexibility in the future

Handle Attributes in the Writer options, allowing the Cache to dictate the ModTime: https://github.com/Shopify/go-storage/pull/8

Requires #5