### PR TITLE
Add Attributes function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ type FS interface {
 	// File when done to release all underlying resources.
 	Open(ctx context.Context, path string, options *ReaderOptions) (*File, error)
 
+	// Attributes returns attributes about a path
+	Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error)
+
 	// Create makes a new file at path in the filesystem.  Callers must close the
 	// returned WriteCloser and check the error to be sure that the file
 	// was successfully written.

--- a/pkg/cache_wrapper.go
+++ b/pkg/cache_wrapper.go
@@ -103,6 +103,15 @@ func (c *cacheWrapper) Open(ctx context.Context, path string, options *ReaderOpt
 	return ff, nil
 }
 
+// Attributes implements FS.
+func (c *cacheWrapper) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	f, err := c.Open(ctx, path, options)
+	if err != nil {
+		return nil, err
+	}
+	return &f.Attributes, nil
+}
+
 // Delete implements FS.
 func (c *cacheWrapper) Delete(ctx context.Context, path string) error {
 	err := c.cache.Delete(ctx, path)

--- a/pkg/cloudstorage_fs.go
+++ b/pkg/cloudstorage_fs.go
@@ -71,6 +71,26 @@ func (c *cloudStorageFS) Open(ctx context.Context, path string, options *ReaderO
 	}, nil
 }
 
+// Attributes implements FS.
+func (c *cloudStorageFS) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	b, err := c.blobBucketHandle(ctx, storage.DevstorageReadOnlyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	a, err := b.Attributes(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Attributes{
+		ContentType: a.ContentType,
+		Metadata:    a.Metadata,
+		ModTime:     a.ModTime,
+		Size:        a.Size,
+	}, nil
+}
+
 // Create implements FS.
 func (c *cloudStorageFS) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	b, err := c.blobBucketHandle(ctx, storage.DevstorageReadWriteScope)

--- a/pkg/fs.go
+++ b/pkg/fs.go
@@ -54,6 +54,9 @@ type FS interface {
 	// File when done to release all underlying resources.
 	Open(ctx context.Context, path string, options *ReaderOptions) (*File, error)
 
+	// Attributes returns attributes about a path
+	Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error)
+
 	// Create makes a new file at path in the filesystem.  Callers must close the
 	// returned WriteCloser and check the error to be sure that the file
 	// was successfully written.

--- a/pkg/fs_test.go
+++ b/pkg/fs_test.go
@@ -23,6 +23,11 @@ func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 	got := string(b)
 	assert.Equal(t, content, got)
 
+	attrs, err := fs.Attributes(ctx, path, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Attributes, *attrs)
+	assert.Len(t, content, int(attrs.Size))
+
 	err = f.Close()
 	assert.NoError(t, err)
 }
@@ -30,6 +35,9 @@ func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 func testOpenNotExists(t *testing.T, fs storage.FS, path string) {
 	ctx := context.Background()
 	_, err := fs.Open(ctx, path, nil)
+	assert.Errorf(t, err, "storage %s: path does not exist", path)
+
+	_, err = fs.Attributes(ctx, path, nil)
 	assert.Errorf(t, err, "storage %s: path does not exist", path)
 }
 

--- a/pkg/hash_wrapper.go
+++ b/pkg/hash_wrapper.go
@@ -42,6 +42,15 @@ func (hfs *hashWrapper) Open(ctx context.Context, path string, options *ReaderOp
 	return hfs.fs.Open(ctx, v, options)
 }
 
+// Attributes implements FS.
+func (hfs *hashWrapper) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	v, err := hfs.gs.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	return hfs.fs.Attributes(ctx, v, options)
+}
+
 // Walk implements Walker.
 func (hfs *hashWrapper) Walk(ctx context.Context, path string, fn WalkFn) error {
 	return errors.New("HashFS.Walk is not implemented")

--- a/pkg/local_fs.go
+++ b/pkg/local_fs.go
@@ -60,6 +60,21 @@ func (l *localFS) Open(_ context.Context, path string, options *ReaderOptions) (
 	}, nil
 }
 
+// Attributes implements FS.
+func (l *localFS) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	path = l.fullPath(path)
+
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, l.wrapError(path, err)
+	}
+
+	return &Attributes{
+		ModTime: stat.ModTime(),
+		Size:    stat.Size(),
+	}, nil
+}
+
 // Create implements FS.  If the path contains any directories which do not already exist
 // then Create will try to make them, returning an error if it fails.
 func (l *localFS) Create(_ context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {

--- a/pkg/logger_wrapper.go
+++ b/pkg/logger_wrapper.go
@@ -42,6 +42,16 @@ func (l *loggerWrapper) Open(ctx context.Context, path string, options *ReaderOp
 	return f, err
 }
 
+// Attributes implements FS.
+func (l *loggerWrapper) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	l.printf("%v: attrs: %v", l.name, path)
+	a, err := l.fs.Attributes(ctx, path, options)
+	if err != nil {
+		l.printf("%v: attrs error: %v: %v", l.name, path, err)
+	}
+	return a, err
+}
+
 // Create implements FS.  All calls to Create are logged and errors are logged separately.
 func (l *loggerWrapper) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	l.printf("%v: create: %v", l.name, path)

--- a/pkg/memory_fs.go
+++ b/pkg/memory_fs.go
@@ -49,6 +49,21 @@ func (m *memoryFS) Open(_ context.Context, path string, options *ReaderOptions) 
 	}
 }
 
+// Attributes implements FS.
+func (m *memoryFS) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	m.RLock()
+	f, ok := m.data[path]
+	m.RUnlock()
+
+	if ok {
+		attrs := f.attrs
+		return &attrs, nil
+	}
+	return nil, &notExistError{
+		Path: path,
+	}
+}
+
 type writingFile struct {
 	*bytes.Buffer
 	path string

--- a/pkg/prefix_wrapper.go
+++ b/pkg/prefix_wrapper.go
@@ -29,6 +29,11 @@ func (p *prefixWrapper) Open(ctx context.Context, path string, options *ReaderOp
 	return p.fs.Open(ctx, p.addPrefix(path), options)
 }
 
+// Attributes() implements FS.
+func (p *prefixWrapper) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	return p.fs.Attributes(ctx, p.addPrefix(path), options)
+}
+
 // Create implements FS.
 func (p *prefixWrapper) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	return p.fs.Create(ctx, p.addPrefix(path), options)

--- a/pkg/s3_fs.go
+++ b/pkg/s3_fs.go
@@ -48,6 +48,25 @@ func (s *s3FS) Open(ctx context.Context, path string, options *ReaderOptions) (*
 	}, nil
 }
 
+func (s *s3FS) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	b, err := s.bucketHandles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	a, err := b.Attributes(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Attributes{
+		ContentType: a.ContentType,
+		Metadata:    a.Metadata,
+		ModTime:     a.ModTime,
+		Size:        a.Size,
+	}, nil
+}
+
 // Create implements FS.
 func (s *s3FS) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
 	b, err := s.bucketHandles(ctx)

--- a/pkg/stats_wrapper.go
+++ b/pkg/stats_wrapper.go
@@ -9,6 +9,8 @@ import (
 const (
 	StatOpenTotal    = "open.total"
 	StatOpenErrors   = "open.errors"
+	StatAttrsTotal   = "attrs.total"
+	StatAttrsErrors  = "attrs.errors"
 	StatCreateTotal  = "create.total"
 	StatCreateErrors = "create.errors"
 	StatDeleteTotal  = "delete.total"
@@ -25,6 +27,9 @@ func NewStatsWrapper(fs FS, name string) FS {
 	status := expvar.NewMap(name)
 	status.Set(StatOpenTotal, new(expvar.Int))
 	status.Set(StatOpenErrors, new(expvar.Int))
+
+	status.Set(StatAttrsTotal, new(expvar.Int))
+	status.Set(StatAttrsErrors, new(expvar.Int))
 
 	status.Set(StatCreateTotal, new(expvar.Int))
 	status.Set(StatCreateErrors, new(expvar.Int))
@@ -55,6 +60,16 @@ func (s *statsWrapper) Open(ctx context.Context, path string, options *ReaderOpt
 	}
 	s.status.Add(StatOpenTotal, 1)
 	return f, err
+}
+
+// Attributes implements FS.  All errors from Attributes are counted.
+func (s *statsWrapper) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	a, err := s.fs.Attributes(ctx, path, options)
+	if err != nil {
+		s.status.Add(StatAttrsErrors, 1)
+	}
+	s.status.Add(StatAttrsTotal, 1)
+	return a, err
 }
 
 // Create implements FS.  All errors from Create are counted.

--- a/pkg/trace_wrapper.go
+++ b/pkg/trace_wrapper.go
@@ -38,6 +38,19 @@ func (t *traceWrapper) Open(ctx context.Context, path string, options *ReaderOpt
 	return t.fs.Open(ctx, path, options)
 }
 
+// Attributes() implements FS.  All calls to Attributes() are logged via golang.org/x/net/trace.
+func (t *traceWrapper) Attributes(ctx context.Context, path string, options *ReaderOptions) (f *Attributes, err error) {
+	if tr, ok := trace.FromContext(ctx); ok {
+		tr.LazyPrintf("%v: attrs: %v", t.name, path)
+		defer func() {
+			if err != nil {
+				tr.LazyPrintf("%v: error: %v", t.name, err)
+				tr.SetError()
+			}
+		}()
+	}
+	return t.fs.Attributes(ctx, path, options)
+}
 
 // Create implements FS.  All calls to Create are logged via golang.org/x/net/trace.
 func (t *traceWrapper) Create(ctx context.Context, path string, options *WriterOptions) (wc io.WriteCloser, err error) {


### PR DESCRIPTION
- Allow getting Attributes only, without trying to open the file.
- On S3 and GCS, this also fetches the Metadata
- On local_fs, it only does a Stat
- On cache_wrapper, it actually uses the Open, reducing a ton of logic with having to deal with Attributes returning different information. This caveat _could_ be tackled in a future update.

Requires #6 