### PR TITLE
Switch to using a dedicated CreationTime

### DIFF
--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -32,17 +32,3 @@ func (e *notExistError) isNotExist() bool { return true }
 func (e *notExistError) Error() string {
 	return fmt.Sprintf("storage %v: path does not exist", e.Path)
 }
-
-// expiredError is returned from FS.Open implementations when a requested
-// path exists, but is expired.
-// It behaves like a notExistError, but with a different error message.
-type expiredError struct {
-	Path string
-}
-
-func (e *expiredError) isNotExist() bool { return true }
-
-// Error implements error
-func (e *expiredError) Error() string {
-	return fmt.Sprintf("storage %v: path exists, but is expired", e.Path)
-}

--- a/pkg/fs.go
+++ b/pkg/fs.go
@@ -30,6 +30,8 @@ type Attributes struct {
 	Metadata map[string]string
 	// ModTime is the time the blob object was last modified.
 	ModTime time.Time
+	// CreationTime is the time the blob object was created.
+	CreationTime time.Time
 	// Size is the size of the object in bytes.
 	Size int64
 }

--- a/pkg/fs_test.go
+++ b/pkg/fs_test.go
@@ -25,8 +25,9 @@ func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 
 	attrs, err := fs.Attributes(ctx, path, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, f.Attributes, *attrs)
-	assert.Len(t, content, int(attrs.Size))
+	assert.Equal(t, f.Attributes.Metadata, attrs.Metadata)
+	assert.Equal(t, f.Attributes.Size, attrs.Size)
+	assert.Equal(t, f.Attributes.ContentType, attrs.ContentType)
 
 	err = f.Close()
 	assert.NoError(t, err)

--- a/pkg/local_fs.go
+++ b/pkg/local_fs.go
@@ -91,9 +91,16 @@ func (l *localFS) Create(_ context.Context, path string, options *WriterOptions)
 	if err != nil {
 		return nil, err
 	}
-	if options != nil && !options.Attributes.ModTime.IsZero() {
-		if err := os.Chtimes(path, options.Attributes.ModTime, options.Attributes.ModTime); err != nil {
-			return f, err
+	if options != nil {
+		if !options.Attributes.CreationTime.IsZero() {
+			// There is no way to store the CreationTime, so overwrite the ModTime
+			// This is necessary so the CacheWrapper can use LocalFS
+			options.Attributes.ModTime = options.Attributes.CreationTime
+		}
+		if !options.Attributes.ModTime.IsZero() {
+			if err := os.Chtimes(path, options.Attributes.ModTime, options.Attributes.ModTime); err != nil {
+				return f, err
+			}
 		}
 	}
 	return f, nil


### PR DESCRIPTION
Allows tracking of the cache freshness when caching in-memory, without overriding the ModTime.

When caching to File, the CreationTime is not available, so hijack the ModTime anyway.

Requires #7