### PR TITLE
Add ability to cache without any data

### DIFF
--- a/pkg/cache_wrapper_test.go
+++ b/pkg/cache_wrapper_test.go
@@ -87,3 +87,15 @@ func TestCacheWrapper_CacheOptions_MaxAge(t *testing.T) {
 		assert.True(t, f2.CreationTime.After(f.CreationTime)) // New cache
 	})
 }
+
+func TestCacheWrapper_CacheOptions_NoData(t *testing.T) {
+	options := &storage.CacheOptions{
+		NoData: true,
+	}
+
+	withCache(options, func(fs storage.FS, src storage.FS, cache storage.FS) {
+		testCreate(t, fs, "foo", "bar")
+
+		testOpenExists(t, cache, "foo", "") // No content actually stored
+	})
+}


### PR DESCRIPTION
If enabled, `Open` will cache the metadata, but proxy the actual `Read` to the source, potentially saving tons of memory.

Requires #8