### PR TITLE
Add a MockFS implementation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/mock_fs.go
+++ b/pkg/mock_fs.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// NewMockFS creates an FS where each method can be mocked.
+// To be used in tests.
+func NewMockFS() *mockFS {
+	return &mockFS{}
+}
+
+type mockFS struct {
+	mock.Mock
+}
+
+func (m *mockFS) Walk(ctx context.Context, path string, fn WalkFn) error {
+	args := m.Called(ctx, path, fn)
+	return args.Error(0)
+}
+
+func (m *mockFS) Open(ctx context.Context, path string, options *ReaderOptions) (*File, error) {
+	args := m.Called(ctx, path, options)
+	file := args.Get(0)
+	err := args.Error(1)
+	return file.(*File), err
+}
+
+func (m *mockFS) Attributes(ctx context.Context, path string, options *ReaderOptions) (*Attributes, error) {
+	args := m.Called(ctx, path, options)
+	attrs := args.Get(0)
+	err := args.Error(1)
+	return attrs.(*Attributes), err
+}
+
+func (m *mockFS) Create(ctx context.Context, path string, options *WriterOptions) (io.WriteCloser, error) {
+	args := m.Called(ctx, path, options)
+	w := args.Get(0)
+	err := args.Error(1)
+	if w == nil {
+		return nil, err
+	}
+	return w.(io.WriteCloser), err
+}
+
+func (m *mockFS) Delete(ctx context.Context, path string) error {
+	args := m.Called(ctx, path)
+	return args.Error(0)
+}
+
+func (m *mockFS) URL(ctx context.Context, path string, options *SignedURLOptions) (string, error) {
+	args := m.Called(ctx, path, options)
+	url := args.String(0)
+	err := args.Error(1)
+	return url, err
+}

--- a/pkg/mock_fs_test.go
+++ b/pkg/mock_fs_test.go
@@ -1,0 +1,90 @@
+package storage_test
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"os"
+	"testing"
+
+	"github.com/Shopify/go-storage/pkg"
+)
+
+func Test_mockFS_Attributes(t *testing.T) {
+	ctx := context.Background()
+	fs := storage.NewMockFS()
+	path := "foo"
+	options := &storage.ReaderOptions{}
+	attrs := &storage.Attributes{}
+
+	fs.On("Attributes", ctx, path, options).Return(attrs, nil)
+	attrs2, err := fs.Attributes(ctx, path, options)
+	assert.NoError(t, err)
+	assert.Equal(t, attrs, attrs2)
+	fs.AssertExpectations(t)
+}
+
+func Test_mockFS_Create(t *testing.T) {
+	ctx := context.Background()
+	fs := storage.NewMockFS()
+	path := "foo"
+	options := &storage.WriterOptions{}
+	w := &os.File{}
+
+	fs.On("Create", ctx, path, options).Return(w, nil)
+	w2, err := fs.Create(ctx, path, options)
+	assert.NoError(t, err)
+	assert.Equal(t, w, w2)
+	fs.AssertExpectations(t)
+}
+
+func Test_mockFS_Delete(t *testing.T) {
+	ctx := context.Background()
+	fs := storage.NewMockFS()
+	path := "foo"
+
+	fs.On("Delete", ctx, path).Return(nil)
+	err := fs.Delete(ctx, path)
+	assert.NoError(t, err)
+	fs.AssertExpectations(t)
+}
+
+func Test_mockFS_Open(t *testing.T) {
+	ctx := context.Background()
+	fs := storage.NewMockFS()
+	path := "foo"
+	options := &storage.ReaderOptions{}
+	file := &storage.File{}
+
+	fs.On("Open", ctx, path, options).Return(file, nil)
+	file2, err := fs.Open(ctx, path, options)
+	assert.NoError(t, err)
+	assert.Equal(t, file, file2)
+	fs.AssertExpectations(t)
+}
+
+func Test_mockFS_URL(t *testing.T) {
+	ctx := context.Background()
+	fs := storage.NewMockFS()
+	path := "foo"
+	options := &storage.SignedURLOptions{}
+	url := "url"
+
+	fs.On("URL", ctx, path, options).Return(url, nil)
+	url2, err := fs.URL(ctx, path, options)
+	assert.NoError(t, err)
+	assert.Equal(t, url, url2)
+	fs.AssertExpectations(t)
+}
+
+func Test_mockFS_Walk(t *testing.T) {
+	ctx := context.Background()
+	fs := storage.NewMockFS()
+	path := "foo"
+	fn := func(path string) error { return nil }
+
+	fs.On("Walk", ctx, path, mock.Anything).Return(nil)
+	err := fs.Walk(ctx, path, fn)
+	assert.NoError(t, err)
+	fs.AssertExpectations(t)
+}


### PR DESCRIPTION
Even though this is meant for test usage, we export it such that clients can use it to test failures.