### PR TITLE
Add a scope concept

### DIFF
--- a/pkg/scope.go
+++ b/pkg/scope.go
@@ -1,0 +1,40 @@
+package storage
+
+import "strings"
+
+type Scope int
+
+const (
+	ScopeRead Scope = 1 << iota
+	ScopeWrite
+	ScopeDelete
+	ScopeSignURL
+
+	ScopeRW  = ScopeRead | ScopeWrite
+	ScopeRWD = ScopeRW | ScopeDelete
+)
+
+func (s Scope) Has(s2 Scope) bool {
+	return s&s2 == s2
+}
+
+func (s Scope) String() string {
+	if s == 0 {
+		return "none"
+	}
+
+	var scopes []string
+	if s.Has(ScopeRead) {
+		scopes = append(scopes, "read")
+	}
+	if s.Has(ScopeWrite) {
+		scopes = append(scopes, "write")
+	}
+	if s.Has(ScopeDelete) {
+		scopes = append(scopes, "delete")
+	}
+	if s.Has(ScopeSignURL) {
+		scopes = append(scopes, "sign")
+	}
+	return strings.Join(scopes, ",")
+}

--- a/pkg/scope_test.go
+++ b/pkg/scope_test.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScope_Has(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   Scope
+		s2   Scope
+		has  bool
+	}{
+		{name: "empty", has: true},
+		{name: "empty,read", s2: ScopeRead, has: false},
+		{name: "read,empty", s1: ScopeRead, has: true},
+		{name: "read,read", s1: ScopeRead, s2: ScopeRead, has: true},
+		{name: "read+write,read", s1: ScopeRead | ScopeWrite, s2: ScopeRead, has: true},
+		{name: "read,read+write", s1: ScopeRead, s2: ScopeRead | ScopeWrite, has: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.has, tt.s1.Has(tt.s2))
+		})
+	}
+}
+
+func TestScope_String(t *testing.T) {
+	tests := []struct {
+		want string
+		s    Scope
+	}{
+		{want: "none"},
+		{want: "read", s: ScopeRead},
+		{want: "read,write", s: ScopeRead | ScopeWrite},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.s.String())
+		})
+	}
+}


### PR DESCRIPTION
- Add a generic `Scope` concept, to represent operations a bucket handle can do.
- Currently only used by GCS, but could be used for S3 as well.
- Also includes `ScopeSignURL`, which is useful to know how to configure the GCS bucket, only requiring the private key for JWT signing when necessary.

This change should be 100% backwards compatible