### PR TITLE
Cache the GCS bucket handle

### DIFF
--- a/pkg/cloudstorage_fs_test.go
+++ b/pkg/cloudstorage_fs_test.go
@@ -137,3 +137,17 @@ func withCloudStorageFS(t testing.TB, cb func(fs storage.FS)) {
 
 	cb(fs)
 }
+
+func Test_ResolveCloudStorageScope(t *testing.T) {
+	tests := map[storage.Scope]storage.Scope{
+		storage.ScopeRead:                         storage.ScopeRead,
+		storage.ScopeWrite:                        storage.ScopeRW,
+		storage.ScopeDelete:                       storage.ScopeRWD,
+		storage.ScopeWrite | storage.ScopeSignURL: storage.ScopeRW | storage.ScopeSignURL,
+	}
+	for input, output := range tests {
+		t.Run(input.String(), func(t *testing.T) {
+			require.Equal(t, output, storage.ResolveCloudStorageScope(input))
+		})
+	}
+}

--- a/pkg/from_url_test.go
+++ b/pkg/from_url_test.go
@@ -10,7 +10,7 @@ func TestFromURL(t *testing.T) {
 	cs := FromURL("gs://foo/bar")
 	assert.Implements(t, (*FS)(nil), cs)
 	assert.IsType(t, (*cloudStorageFS)(nil), cs)
-	assert.Equal(t, "foo/bar", cs.(*cloudStorageFS).bucket)
+	assert.Equal(t, "foo/bar", cs.(*cloudStorageFS).bucketName)
 
 	s3 := FromURL("s3://foo/bar")
 	assert.Implements(t, (*FS)(nil), s3)


### PR DESCRIPTION
Alternative approach to fix Shopify/go-storage#20, caching the bucket handle (and the http client) instead of the credentials

Depends on #22

- Initialize the bucket just-in-time, with the requested scope.
- Initialize a new bucket with expanded scopes, if necessary.

This change should be 100% backwards compatible.

I considered changing the constructor to expect a scope, but it was breaking compatibility and I did not feel like creating a v2 for this package while avoidable. The performance impact of reopening the bucket if the scope needs expanding should be negligible.

While considering moving the scope to the constructor, I also considered moving the bucket handle creation, which would avoid needing a mutex and race condition detection, but I would have needed to move error handling to it as well, which would have further broke compatibility, in signature and in concept.