### PR TITLE
Move CI to GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    tags:
+    - v*
+    branches:
+    - master
+    - main
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.32
+
+  mod-tidy:
+    name: Go Mod Tidy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: 1.15.x
+
+    - name: Cache
+      uses: actions/cache@v2.1.2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Tidy
+      run: |
+        cp go.sum{,.old}
+        go mod tidy
+        diff go.sum{.old,}
+
+  test:
+    name: Go ${{ matrix.go-version }} test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version:
+        - 1.13.x
+        - 1.14.x
+        - 1.15.x
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache
+      uses: actions/cache@v2.1.2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Test
+      run: go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: go
-go:
-- 1.13
-- tip
-go_import_path: github.com/Shopify/go-storage


### PR DESCRIPTION
- Move away from Travis CI to rely on our org's GitHub plan.
- Add a `go mod tidy` test
