### PR TITLE
Add support for ContentEncoding

### DIFF
--- a/cloudstorage_fs.go
+++ b/cloudstorage_fs.go
@@ -91,10 +91,11 @@ func (c *cloudStorageFS) Attributes(ctx context.Context, path string, options *R
 	}
 
 	return &Attributes{
-		ContentType: a.ContentType,
-		Metadata:    a.Metadata,
-		ModTime:     a.ModTime,
-		Size:        a.Size,
+		ContentType:     a.ContentType,
+		ContentEncoding: a.ContentEncoding,
+		Metadata:        a.Metadata,
+		ModTime:         a.ModTime,
+		Size:            a.Size,
 	}, nil
 }
 
@@ -107,9 +108,10 @@ func (c *cloudStorageFS) Create(ctx context.Context, path string, options *Write
 	var blobOpts *blob.WriterOptions
 	if options != nil {
 		blobOpts = &blob.WriterOptions{
-			Metadata:    options.Attributes.Metadata,
-			ContentType: options.Attributes.ContentType,
-			BufferSize:  options.BufferSize,
+			Metadata:        options.Attributes.Metadata,
+			ContentType:     options.Attributes.ContentType,
+			ContentEncoding: options.Attributes.ContentEncoding,
+			BufferSize:      options.BufferSize,
 		}
 	}
 	return b.NewWriter(ctx, path, blobOpts)

--- a/fs.go
+++ b/fs.go
@@ -21,6 +21,8 @@ type File struct {
 type Attributes struct {
 	// ContentType is the MIME type of the blob object. It will not be empty.
 	ContentType string
+	// ContentEncoding specifies the encoding used for the blob's content, if any.
+	ContentEncoding string
 	// Metadata holds key/value pairs associated with the blob.
 	// Keys are guaranteed to be in lowercase, even if the backend provider
 	// has case-sensitive keys (although note that Metadata written via

--- a/fs_test.go
+++ b/fs_test.go
@@ -28,6 +28,7 @@ func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 	assert.Equal(t, f.Attributes.Metadata, attrs.Metadata)
 	assert.Equal(t, f.Attributes.Size, attrs.Size)
 	assert.Equal(t, f.Attributes.ContentType, attrs.ContentType)
+	assert.Equal(t, f.Attributes.ContentEncoding, attrs.ContentEncoding)
 
 	err = f.Close()
 	assert.NoError(t, err)

--- a/s3_fs.go
+++ b/s3_fs.go
@@ -77,9 +77,10 @@ func (s *s3FS) Create(ctx context.Context, path string, options *WriterOptions) 
 	var blobOpts *blob.WriterOptions
 	if options != nil {
 		blobOpts = &blob.WriterOptions{
-			Metadata:    options.Attributes.Metadata,
-			ContentType: options.Attributes.ContentType,
-			BufferSize:  options.BufferSize,
+			Metadata:        options.Attributes.Metadata,
+			ContentType:     options.Attributes.ContentType,
+			ContentEncoding: options.Attributes.ContentEncoding,
+			BufferSize:      options.BufferSize,
 		}
 	}
 	return b.NewWriter(ctx, path, blobOpts)


### PR DESCRIPTION
Add support for ContentEncoding.

Google Cloud Storage knows how to handle `ContentEncoding: gzip` (https://cloud.google.com/storage/docs/transcoding)