### PR TITLE
Remove use of github.com/pkg/errors

### DIFF
--- a/cloudstorage_fs.go
+++ b/cloudstorage_fs.go
@@ -2,13 +2,13 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 	"time"
 
 	gstorage "cloud.google.com/go/storage"
-	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
@@ -209,7 +209,7 @@ func (c *cloudStorageFS) findCredentials(ctx context.Context, scope string) (*go
 func (c *cloudStorageFS) client(ctx context.Context, scope Scope) (*gstorage.Client, error) {
 	creds, err := c.findCredentials(ctx, cloudStorageScope(scope))
 	if err != nil {
-		return nil, errors.Wrap(err, "cloud storage: unable to retrieve default token source")
+		return nil, fmt.Errorf("finding credentials: %w", err)
 	}
 
 	var options []option.ClientOption
@@ -218,7 +218,7 @@ func (c *cloudStorageFS) client(ctx context.Context, scope Scope) (*gstorage.Cli
 
 	client, err := gstorage.NewClient(ctx, options...)
 	if err != nil {
-		return nil, errors.Wrap(err, "cloud storage: unable to build client")
+		return nil, fmt.Errorf("building client: %w", err)
 	}
 
 	return client, nil

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	cloud.google.com/go/storage v1.18.2
-	github.com/pkg/errors v0.9.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	google.golang.org/api v0.58.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/pkg/errors v0.9.0 h1:J8lpUdobwIeCI7OiSxHqEwJUKvJwicL5+3v1oe2Yb4k=
-github.com/pkg/errors v0.9.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Instead, rely on `errors` and `fmt.Errorf`, which are built-in libraries