### PR TITLE
Move testutils to an internal package

### DIFF
--- a/cache_wrapper_test.go
+++ b/cache_wrapper_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 func withCache(options *storage.CacheOptions, cb func(fs storage.FS, src storage.FS, cache storage.FS)) {
@@ -30,37 +31,37 @@ func withFileCache(options *storage.CacheOptions, cb func(fs storage.FS, src sto
 
 func TestCacheWrapper_Open(t *testing.T) {
 	withCache(nil, func(fs storage.FS, src storage.FS, cache storage.FS) {
-		testOpenNotExists(t, fs, "foo")
+		testutils.OpenNotExists(t, fs, "foo")
 	})
 }
 
 func TestCacheWrapper_Create(t *testing.T) {
 	withCache(nil, func(fs storage.FS, src storage.FS, cache storage.FS) {
-		testCreate(t, fs, "foo", "")
-		testOpenExists(t, src, "foo", "")
-		testOpenExists(t, cache, "foo", "")
+		testutils.Create(t, fs, "foo", "")
+		testutils.OpenExists(t, src, "foo", "")
+		testutils.OpenExists(t, cache, "foo", "")
 
-		testCreate(t, fs, "foo", "bar")
-		testOpenExists(t, src, "foo", "bar")
-		testOpenExists(t, cache, "foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
+		testutils.OpenExists(t, src, "foo", "bar")
+		testutils.OpenExists(t, cache, "foo", "bar")
 	})
 }
 
 func TestCacheWrapper_Create_fileCache(t *testing.T) {
 	withFileCache(nil, func(fs storage.FS, src storage.FS, cache storage.FS) {
-		testCreate(t, fs, "foo", "")
-		testOpenExists(t, src, "foo", "")
-		testOpenExists(t, cache, "foo", "")
+		testutils.Create(t, fs, "foo", "")
+		testutils.OpenExists(t, src, "foo", "")
+		testutils.OpenExists(t, cache, "foo", "")
 
-		testCreate(t, fs, "foo", "bar")
-		testOpenExists(t, src, "foo", "bar")
-		testOpenExists(t, cache, "foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
+		testutils.OpenExists(t, src, "foo", "bar")
+		testutils.OpenExists(t, cache, "foo", "bar")
 	})
 }
 
 func TestCacheWrapper_Delete(t *testing.T) {
 	withCache(nil, func(fs storage.FS, src storage.FS, cache storage.FS) {
-		testDelete(t, fs, "foo")
+		testutils.Delete(t, fs, "foo")
 	})
 }
 
@@ -70,7 +71,7 @@ func TestCacheWrapper_CacheOptions_MaxAge(t *testing.T) {
 	}
 
 	withCache(options, func(fs storage.FS, src storage.FS, cache storage.FS) {
-		testCreate(t, fs, "foo", "")
+		testutils.Create(t, fs, "foo", "")
 
 		ctx := context.Background()
 		f, err := fs.Open(ctx, "foo", nil)
@@ -94,8 +95,8 @@ func TestCacheWrapper_CacheOptions_NoData(t *testing.T) {
 	}
 
 	withCache(options, func(fs storage.FS, src storage.FS, cache storage.FS) {
-		testCreate(t, fs, "foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
 
-		testOpenExists(t, cache, "foo", "") // No content actually stored
+		testutils.OpenExists(t, cache, "foo", "") // No content actually stored
 	})
 }

--- a/cloudstorage_fs_test.go
+++ b/cloudstorage_fs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 func BenchmarkCloudStorageFS(b *testing.B) {
@@ -74,7 +75,7 @@ func Test_cloudStorageFS_URL(t *testing.T) {
 	withCloudStorageFS(t, func(fs storage.FS) {
 		path := "foo"
 		contents := "test"
-		testCreate(t, fs, path, contents)
+		testutils.Create(t, fs, path, contents)
 
 		url, err := fs.URL(context.Background(), path, nil)
 		require.NoError(t, err)
@@ -95,8 +96,8 @@ func Test_cloudStorageFS_Open(t *testing.T) {
 	withCloudStorageFS(t, func(fs storage.FS) {
 		path := "foo"
 		contents := "test"
-		testCreate(t, fs, path, contents)
-		testOpenExists(t, fs, path, contents)
+		testutils.Create(t, fs, path, contents)
+		testutils.OpenExists(t, fs, path, contents)
 	})
 }
 
@@ -104,7 +105,7 @@ func Test_cloudStorageFS_Create(t *testing.T) {
 	withCloudStorageFS(t, func(fs storage.FS) {
 		path := "foo"
 		contents := "test"
-		testCreate(t, fs, path, contents)
+		testutils.Create(t, fs, path, contents)
 	})
 }
 
@@ -112,8 +113,8 @@ func Test_cloudStorageFS_Delete(t *testing.T) {
 	withCloudStorageFS(t, func(fs storage.FS) {
 		path := "foo"
 		contents := "test"
-		testCreate(t, fs, path, contents)
-		testDelete(t, fs, path)
+		testutils.Create(t, fs, path, contents)
+		testutils.Delete(t, fs, path)
 	})
 }
 
@@ -136,7 +137,7 @@ func withCloudStorageFS(tb testing.TB, cb func(fs storage.FS)) {
 	prefix := fmt.Sprintf("test-go-storage/%x/", sha1.New().Sum(randomBytes))
 
 	fs = storage.NewPrefixWrapper(fs, prefix)
-	defer testRemoveAll(tb, fs)
+	defer testutils.RemoveAll(tb, fs)
 
 	cb(fs)
 }

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -1,4 +1,4 @@
-package storage_test
+package testutils
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"github.com/Shopify/go-storage"
 )
 
-func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
+func OpenExists(t *testing.T, fs storage.FS, path string, content string) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -35,7 +35,7 @@ func testOpenExists(t *testing.T, fs storage.FS, path string, content string) {
 	assert.NoError(t, err)
 }
 
-func testOpenNotExists(t *testing.T, fs storage.FS, path string) {
+func OpenNotExists(t *testing.T, fs storage.FS, path string) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -46,7 +46,7 @@ func testOpenNotExists(t *testing.T, fs storage.FS, path string) {
 	assert.Errorf(t, err, "storage %s: path does not exist", path)
 }
 
-func testCreate(t *testing.T, fs storage.FS, path string, content string) {
+func Create(t *testing.T, fs storage.FS, path string, content string) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -59,22 +59,22 @@ func testCreate(t *testing.T, fs storage.FS, path string, content string) {
 	err = wc.Close()
 	assert.NoError(t, err)
 
-	testOpenExists(t, fs, path, content)
+	OpenExists(t, fs, path, content)
 }
 
-func testDelete(t *testing.T, fs storage.FS, path string) {
+func Delete(t *testing.T, fs storage.FS, path string) {
 	t.Helper()
 	ctx := context.Background()
 
-	testCreate(t, fs, path, "foo")
+	Create(t, fs, path, "foo")
 
 	err := fs.Delete(ctx, path)
 	assert.NoError(t, err)
 
-	testOpenNotExists(t, fs, path)
+	OpenNotExists(t, fs, path)
 }
 
-func testRemoveAll(tb testing.TB, fs storage.FS) {
+func RemoveAll(tb testing.TB, fs storage.FS) {
 	tb.Helper()
 	ctx := context.Background()
 

--- a/local_fs_test.go
+++ b/local_fs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 func withLocal(cb func(storage.FS)) {
@@ -21,19 +22,19 @@ func withLocal(cb func(storage.FS)) {
 
 func TestLocalOpen(t *testing.T) {
 	withLocal(func(fs storage.FS) {
-		testOpenNotExists(t, fs, "foo")
+		testutils.OpenNotExists(t, fs, "foo")
 	})
 }
 
 func TestLocalCreate(t *testing.T) {
 	withLocal(func(fs storage.FS) {
-		testCreate(t, fs, "foo", "")
-		testCreate(t, fs, "foo", "bar")
+		testutils.Create(t, fs, "foo", "")
+		testutils.Create(t, fs, "foo", "bar")
 	})
 }
 
 func TestLocalDelete(t *testing.T) {
 	withLocal(func(fs storage.FS) {
-		testDelete(t, fs, "foo")
+		testutils.Delete(t, fs, "foo")
 	})
 }

--- a/memory_fs_test.go
+++ b/memory_fs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 func withMem(cb func(storage.FS)) {
@@ -12,19 +13,19 @@ func withMem(cb func(storage.FS)) {
 
 func TestMemOpen(t *testing.T) {
 	withMem(func(fs storage.FS) {
-		testOpenNotExists(t, fs, "foo")
+		testutils.OpenNotExists(t, fs, "foo")
 	})
 }
 
 func TestMemCreate(t *testing.T) {
 	withMem(func(fs storage.FS) {
-		testCreate(t, fs, "foo", "")
-		testCreate(t, fs, "foo", "bar")
+		testutils.Create(t, fs, "foo", "")
+		testutils.Create(t, fs, "foo", "bar")
 	})
 }
 
 func TestMemDelete(t *testing.T) {
 	withMem(func(fs storage.FS) {
-		testDelete(t, fs, "foo")
+		testutils.Delete(t, fs, "foo")
 	})
 }

--- a/prefix_wrapper_test.go
+++ b/prefix_wrapper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 const prefix = "testPrefix/"
@@ -16,26 +17,26 @@ func withPrefix(cb func(fs storage.FS, src storage.FS)) {
 
 func TestPrefixOpen(t *testing.T) {
 	withPrefix(func(fs storage.FS, src storage.FS) {
-		testOpenNotExists(t, fs, "foo")
+		testutils.OpenNotExists(t, fs, "foo")
 	})
 }
 
 func TestPrefixCreate(t *testing.T) {
 	withPrefix(func(fs storage.FS, src storage.FS) {
-		testCreate(t, fs, "foo", "")
-		testOpenExists(t, src, "testPrefix/foo", "")
+		testutils.Create(t, fs, "foo", "")
+		testutils.OpenExists(t, src, "testPrefix/foo", "")
 
-		testCreate(t, fs, "foo", "bar")
-		testOpenExists(t, src, "testPrefix/foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
+		testutils.OpenExists(t, src, "testPrefix/foo", "bar")
 	})
 }
 
 func TestPrefixDelete(t *testing.T) {
 	withPrefix(func(fs storage.FS, src storage.FS) {
-		testCreate(t, src, "testPrefix/foo", "bar")
-		testOpenExists(t, fs, "foo", "bar")
+		testutils.Create(t, src, "testPrefix/foo", "bar")
+		testutils.OpenExists(t, fs, "foo", "bar")
 
-		testDelete(t, fs, "foo")
-		testOpenNotExists(t, fs, "foo")
+		testutils.Delete(t, fs, "foo")
+		testutils.OpenNotExists(t, fs, "foo")
 	})
 }

--- a/slow_wrapper_test.go
+++ b/slow_wrapper_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 const slowDelay = 400 * time.Millisecond
@@ -20,7 +21,7 @@ func TestNewSlowWrapper(t *testing.T) {
 		start := time.Now()
 
 		// testCreate will do a Create, Open, and Attributes, so 3 calls
-		testCreate(t, fs, "foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
 		assert.WithinDuration(t, start.Add(slowDelay*3), time.Now(), slowDelay)
 	})
 }

--- a/stats_wrapper_test.go
+++ b/stats_wrapper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 func TestNewStatsWrapper(t *testing.T) {
@@ -17,7 +18,7 @@ func TestNewStatsWrapper(t *testing.T) {
 		testStats := fmt.Sprintf("test-go-storage-%x", sha1.New().Sum(randomBytes))
 		fs := storage.NewStatsWrapper(localFS, testStats)
 
-		testDelete(t, fs, "foo")
+		testutils.Delete(t, fs, "foo")
 
 		stats := expvar.Get(testStats).(*expvar.Map)
 		assert.Equal(t, int64(2), stats.Get(storage.StatOpenTotal).(*expvar.Int).Value())

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Shopify/go-storage"
+	"github.com/Shopify/go-storage/internal/testutils"
 )
 
 func TestExists(t *testing.T) {
@@ -14,7 +15,7 @@ func TestExists(t *testing.T) {
 
 	withMem(func(fs storage.FS) {
 		assert.False(t, storage.Exists(ctx, fs, "foo"))
-		testCreate(t, fs, "foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
 		assert.True(t, storage.Exists(ctx, fs, "foo"))
 	})
 }
@@ -22,7 +23,7 @@ func TestExists(t *testing.T) {
 func TestRead(t *testing.T) {
 	ctx := context.Background()
 	withMem(func(fs storage.FS) {
-		testCreate(t, fs, "foo", "bar")
+		testutils.Create(t, fs, "foo", "bar")
 
 		data, err := storage.Read(ctx, fs, "foo", nil)
 		assert.NoError(t, err)
@@ -34,6 +35,6 @@ func TestWrite(t *testing.T) {
 	ctx := context.Background()
 	withMem(func(fs storage.FS) {
 		assert.NoError(t, storage.Write(ctx, fs, "foo", []byte("bar"), nil))
-		testOpenExists(t, fs, "foo", "bar")
+		testutils.OpenExists(t, fs, "foo", "bar")
 	})
 }


### PR DESCRIPTION
This allows expose public methods on the main package, such that it can be used by [submodules](https://github.com/Shopify/go-storage/pull/334), without exposing the methods outside this package, such that we don't have to support them going forward.