### PR TITLE
Update Slack channel

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,5 @@
 slack_channels:
-- dev-infrastructure
+- courier-operations
 security:
   data_management:
     contains_pii: false


### PR DESCRIPTION
Fix https://github.com/Shopify/services/issues/1808

The `#dev-infrastructure` channel does not exist anymore. Use `#courier-operations` for now as the team is the only user of this library.