### PR TITLE
Remove slack channel from services.yml (not an operating service)

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,3 @@
-slack_channels:
-- courier-operations
 security:
   data_management:
     contains_pii: false


### PR DESCRIPTION
See https://github.com/Shopify/go-storage/pull/278