### PR TITLE
Add ReaderOption.ReadCompressed to control auto-transcoding

### DIFF
--- a/cloudstorage_fs.go
+++ b/cloudstorage_fs.go
@@ -59,7 +59,12 @@ func (c *cloudStorageFS) Open(ctx context.Context, path string, options *ReaderO
 		return nil, err
 	}
 
-	f, err := b.Object(path).NewReader(ctx)
+	obj := b.Object(path)
+	if options != nil {
+		obj = obj.ReadCompressed(options.ReadCompressed)
+	}
+
+	f, err := obj.NewReader(ctx)
 	if err != nil {
 		if errors.Is(err, gstorage.ErrObjectNotExist) {
 			return nil, &notExistError{

--- a/fs.go
+++ b/fs.go
@@ -39,7 +39,12 @@ type Attributes struct {
 // ReaderOptions are used to modify the behaviour of read operations.
 // Inspired from gocloud.dev/blob.ReaderOptions
 // It is provided for future extensibility.
-type ReaderOptions struct{}
+type ReaderOptions struct {
+	// ReadCompressed controls whether the file must be uncompressed based on Content-Encoding.
+	// Only respected by Google Cloud Storage: https://cloud.google.com/storage/docs/transcoding
+	// Common pitfall: https://github.com/googleapis/google-cloud-go/issues/1743
+	ReadCompressed bool
+}
 
 // WriterOptions are used to modify the behaviour of write operations.
 // Inspired from gocloud.dev/blob.WriterOptions


### PR DESCRIPTION
### Context

The Google Cloud Storage library has an [auto-transcoding](https://cloud.google.com/storage/docs/transcoding) feature that uncompress files before serving them (only gzip is supported).

Basically, GCS respects the `Accept-Encoding: gzip` header sent by the HTTP client.

By default the GCS Go client does not send it, but we can force it to do so with [`ReadCompressed()`](https://pkg.go.dev/cloud.google.com/go/storage#ObjectHandle.ReadCompressed).

### Changes

- Adds a `ReaderOption.ReadCompressed` option
- Update the Cloud Storage implementation to implement it



Note: see this interesting behaviour described in this issue: https://github.com/googleapis/google-cloud-go/issues/1743
